### PR TITLE
Process definitions instead of process model

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.3.0",
     "@process-engine/deployment_api_contracts": "feature~process_definitions_instead_of_process_model",
-    "@process-engine/process_engine_contracts": "^17.0.0"
+    "@process-engine/process_engine_contracts": "feature~process_definitions_instead_of_process_model",
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.3.0",
     "@process-engine/deployment_api_contracts": "feature~process_definitions_instead_of_process_model",
-    "@process-engine/process_engine_contracts": "feature~process_definitions_instead_of_process_model",
+    "@process-engine/process_engine_contracts": "feature~process_definitions_instead_of_process_model"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/process-engine/deployment_api_core#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.3.0",
-    "@process-engine/deployment_api_contracts": "^0.1.0",
+    "@process-engine/deployment_api_contracts": "feature~process_definitions_instead_of_process_model",
     "@process-engine/process_engine_contracts": "^17.0.0"
   },
   "devDependencies": {

--- a/src/deployment_api_service.ts
+++ b/src/deployment_api_service.ts
@@ -1,5 +1,5 @@
 import {UnauthorizedError} from '@essential-projects/errors_ts';
-import {DeploymentContext, IDeploymentApiService, ImportProcessModelRequestPayload} from '@process-engine/deployment_api_contracts';
+import {DeploymentContext, IDeploymentApiService, ImportProcessDefinitionsRequestPayload} from '@process-engine/deployment_api_contracts';
 
 import {
   ExecutionContext,
@@ -31,7 +31,7 @@ export class DeploymentApiService implements IDeploymentApiService {
     return this._processModelService;
   }
 
-  public async importBpmnFromXml(context: DeploymentContext, payload: ImportProcessModelRequestPayload): Promise<void> {
+  public async importBpmnFromXml(context: DeploymentContext, payload: ImportProcessDefinitionsRequestPayload): Promise<void> {
 
     this._ensureIsAuthorized(context);
 
@@ -48,7 +48,7 @@ export class DeploymentApiService implements IDeploymentApiService {
 
   public async importBpmnFromFile(context: DeploymentContext,
                                   filePath: string,
-                                  processName?: string,
+                                  name?: string,
                                   overwriteExisting: boolean = true,
                                  ): Promise<void> {
 
@@ -61,8 +61,8 @@ export class DeploymentApiService implements IDeploymentApiService {
     const parsedFileName: path.ParsedPath = path.parse(filePath);
     const xml: string = await this._getXmlFromFile(filePath);
 
-    const importPayload: ImportProcessModelRequestPayload = {
-      name: processName || parsedFileName.name,
+    const importPayload: ImportProcessDefinitionsRequestPayload = {
+      name: name || parsedFileName.name,
       xml: xml,
       overwriteExisting: overwriteExisting,
     };


### PR DESCRIPTION
Depends on:
* https://github.com/process-engine/deployment_api_contracts/pull/3
* https://github.com/process-engine/process_engine_contracts/pull/58

## What did you change?

* renamed `ImportProcessModelRequestPayload` to `ImportProcessDefinitionsRequestPayload` to reflect the change of entity
   * the former parameter for `processName` now expects a name - independent from the process

## How can others test the changes?

All integration tests in meta repositories should run successfully: 

* https://github.com/process-engine/management_api_meta/pull/6
* https://github.com/process-engine/consumer_api_meta/pull/40
* https://github.com/process-engine/deployment_api_meta/pull/3
* https://github.com/process-engine/process_engine_meta/pull/122

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
