### PR TITLE
✨ Undeploy process models

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -6,7 +6,7 @@ function registerInContainer(container) {
 
   container
     .register('DeploymentApiService', DeploymentApiService)
-    .dependencies('ProcessModelService')
+    .dependencies('ProcessModelUseCases')
     .singleton();
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/process-engine/deployment_api_core#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
-    "@process-engine/deployment_api_contracts": "feature~undeploy_process_models",
+    "@process-engine/deployment_api_contracts": "2.0.0-480671dd-b20",
     "@process-engine/process_model.contracts": "^2.0.0",
     "moment": "~2.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/process-engine/deployment_api_core#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
-    "@process-engine/deployment_api_contracts": "^1.0.0",
+    "@process-engine/deployment_api_contracts": "feature~undeploy_process_models",
     "@process-engine/process_model.contracts": "^2.0.0",
     "moment": "~2.24.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/deployment_api_core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Contains all the core components for the deployment api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/deployment_api_service.ts
+++ b/src/deployment_api_service.ts
@@ -46,6 +46,8 @@ export class DeploymentApiService implements IDeploymentApi {
   }
 
   public async undeploy(identity: IIdentity, processModelId: string): Promise<void> {
+    this._ensureIsAuthorized(identity);
+
     return this._processModelUseCases.deleteProcessModel(identity, processModelId);
   }
 

--- a/src/deployment_api_service.ts
+++ b/src/deployment_api_service.ts
@@ -6,21 +6,19 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {IDeploymentApi, ImportProcessDefinitionsRequestPayload} from '@process-engine/deployment_api_contracts';
 
-import {IProcessModelService} from '@process-engine/process_model.contracts';
+import {IProcessModelUseCases} from '@process-engine/process_model.contracts';
 
 export class DeploymentApiService implements IDeploymentApi {
+  private _processModelUseCases: IProcessModelUseCases;
 
-  private _processModelService: IProcessModelService;
-
-  constructor(processModelService: IProcessModelService) {
-    this._processModelService = processModelService;
+  constructor(processModelUseCases: IProcessModelUseCases) {
+    this._processModelUseCases = processModelUseCases;
   }
 
   public async importBpmnFromXml(identity: IIdentity, payload: ImportProcessDefinitionsRequestPayload): Promise<void> {
-
     this._ensureIsAuthorized(identity);
 
-    await this._processModelService.persistProcessDefinitions(identity, payload.name, payload.xml, payload.overwriteExisting);
+    await this._processModelUseCases.persistProcessDefinitions(identity, payload.name, payload.xml, payload.overwriteExisting);
   }
 
   public async importBpmnFromFile(identity: IIdentity,

--- a/src/deployment_api_service.ts
+++ b/src/deployment_api_service.ts
@@ -45,6 +45,10 @@ export class DeploymentApiService implements IDeploymentApi {
     await this.importBpmnFromXml(identity, importPayload);
   }
 
+  public async undeploy(identity: IIdentity, processModelId: string): Promise<void> {
+    return this._processModelUseCases.deleteProcessModel(identity, processModelId);
+  }
+
   private async _getXmlFromFile(filePath: string): Promise<string> {
     return new Promise<string>((resolve: Function, reject: Function): void => {
       fs.readFile(filePath, 'utf8', (error: Error, xmlString: string): void => {


### PR DESCRIPTION
**Changes:**

1. Use `ProcessModelUseCases` instead of `ProcessModelService`.
2. Implement `undeploy` UseCase.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/259

PR: #7

## How can others test the changes?

Try to undeploy ProcessModels through the Deployment API.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).